### PR TITLE
Store payment methods

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Run PHP CS Fixer
         uses: docker://oskarstark/php-cs-fixer-ga
         with:
-          args: --config=.php-cs-fixer.dist.php --allow-risky=yes --dry-run
+          args: --config=.php-cs-fixer.dist.php --allow-risky=yes --verbose --dry-run

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -14,4 +14,4 @@ return $config->setRules(
     'ordered_imports' => ['sort_algorithm' => 'alpha'],
     'no_unused_imports' => true,
   ]
-)->setLineEnding("\r\n")->setFinder($finder);
+)->setLineEnding(PHP_EOL)->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "vimeo/psalm": "^4.8"
     },
     "scripts": {
-        "format": [ "vendor/bin/php-cs-fixer fix --allow-risky=yes" ],
+        "cs-check": [ "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --allow-risky=yes --using-cache=no --verbose --dry-run" ],
+        "cs-fix": [ "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php --allow-risky=yes --using-cache=no" ],
         "psalm": [ "vendor/bin/psalm" ]
     }
 }

--- a/examples/api_key.php
+++ b/examples/api_key.php
@@ -1,0 +1,19 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use BTCPayServer\Client\ApiKey;
+
+// Fill in with your BTCPay Server data.
+$apiKey = '';
+$host = ''; // e.g. https://your.btcpay-server.tld
+$storeId = '';
+$invoiceId = '';
+
+// Get information about store on BTCPay Server.
+try {
+    $client = new ApiKey($host, $apiKey);
+    var_dump($client->getCurrent());
+} catch (\Throwable $e) {
+    echo "Error: " . $e->getMessage();
+}

--- a/examples/payment_methods.php
+++ b/examples/payment_methods.php
@@ -26,6 +26,8 @@ try {
     echo PHP_EOL . 'Fetch all OnChain payment methods:' . PHP_EOL;
     $clientOC = new StorePaymentMethodOnChain($host, $apiKey);
     var_dump($clientOC->getPaymentMethods($storeId));
+    echo PHP_EOL. 'Preview OnChain addresses for cryptoCode:' . PHP_EOL;
+    var_dump($clientOC->previewPaymentMethodAddresses($storeId, $cryptoCode));
     echo PHP_EOL. 'Fetch single OnChain payment method:' . PHP_EOL;
     var_dump($clientOC->getPaymentMethod($storeId, $cryptoCode));
     echo PHP_EOL . 'Fetch all LightningNetwork methods:' . PHP_EOL;

--- a/examples/payment_methods.php
+++ b/examples/payment_methods.php
@@ -1,0 +1,40 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use BTCPayServer\Client\StorePaymentMethod;
+use BTCPayServer\Client\StorePaymentMethodLightningNetwork;
+use BTCPayServer\Client\StorePaymentMethodOnChain;
+
+// Fill in with your BTCPay Server data.
+$apiKey = '';
+$host = ''; // e.g. https://your.btcpay-server.tld
+$storeId = '';
+$cryptoCode = 'BTC';
+
+$updatePayload = [
+    'enabled' => true,
+    // Needs fixing see, https://github.com/btcpayserver/btcpayserver/issues/2860
+    'connectionString' => 'Internal Node' // external would be 'type=clightning;server=tcp://1.1.1.1:27743/',
+];
+
+// Payment methods examples.
+try {
+    echo 'Fetch all OnChain + LightningNetwork payment methods:' . PHP_EOL;
+    $clientGlobal = new StorePaymentMethod($host, $apiKey);
+    var_dump($clientGlobal->getPaymentMethods($storeId));
+    echo PHP_EOL . 'Fetch all OnChain payment methods:' . PHP_EOL;
+    $clientOC = new StorePaymentMethodOnChain($host, $apiKey);
+    var_dump($clientOC->getPaymentMethods($storeId));
+    echo PHP_EOL. 'Fetch single OnChain payment method:' . PHP_EOL;
+    var_dump($clientOC->getPaymentMethod($storeId, $cryptoCode));
+    echo PHP_EOL . 'Fetch all LightningNetwork methods:' . PHP_EOL;
+    $clientLN = new StorePaymentMethodLightningNetwork($host, $apiKey);
+    var_dump($clientLN->getPaymentMethods($storeId));
+    echo PHP_EOL . 'Fetch single LN payment method:' . PHP_EOL;
+    var_dump($clientLN->getPaymentMethods($storeId, $cryptoCode));
+    echo PHP_EOL . 'Disable BTC LN payment method:' . PHP_EOL;
+    var_dump($clientLN->updatePaymentMethod($storeId, $cryptoCode, $updatePayload));
+} catch (\Throwable $e) {
+    echo "Error: " . $e->getMessage();
+}

--- a/examples/payment_methods.php
+++ b/examples/payment_methods.php
@@ -13,7 +13,7 @@ $storeId = '';
 $cryptoCode = 'BTC';
 
 $updatePayload = [
-    'enabled' => true,
+    'enabled' => false,
     // Needs fixing see, https://github.com/btcpayserver/btcpayserver/issues/2860
     'connectionString' => 'Internal Node' // external would be 'type=clightning;server=tcp://1.1.1.1:27743/',
 ];

--- a/src/Client/AbstractClient.php
+++ b/src/Client/AbstractClient.php
@@ -26,6 +26,11 @@ class AbstractClient
 
     protected function getBaseUrl(): string
     {
+        return $this->baseUrl;
+    }
+
+    protected function getApiUrl(): string
+    {
         return $this->baseUrl . $this->apiPath;
     }
 

--- a/src/Client/AbstractStorePaymentMethodClient.php
+++ b/src/Client/AbstractStorePaymentMethodClient.php
@@ -6,8 +6,11 @@ namespace BTCPayServer\Client;
 
 abstract class AbstractStorePaymentMethodClient extends AbstractClient
 {
-    abstract public function getPaymentMethods(string $storeId);
+    const PAYMENT_TYPE_ONCHAIN = 'OnChain';
+    const PAYMENT_TYPE_LIGHTNING = 'LightningNetwork';
+
+    abstract public function getPaymentMethods(string $storeId): array;
     abstract public function getPaymentMethod(string $storeId, string $cryptoCode);
     abstract public function updatePaymentMethod(string $storeId, string $cryptoCode, array $settings);
-    abstract public function removePaymentMethod(string $storeId, string $cryptoCode);
+    abstract public function removePaymentMethod(string $storeId, string $cryptoCode): bool;
 }

--- a/src/Client/AbstractStorePaymentMethodClient.php
+++ b/src/Client/AbstractStorePaymentMethodClient.php
@@ -6,8 +6,8 @@ namespace BTCPayServer\Client;
 
 abstract class AbstractStorePaymentMethodClient extends AbstractClient
 {
-    const PAYMENT_TYPE_ONCHAIN = 'OnChain';
-    const PAYMENT_TYPE_LIGHTNING = 'LightningNetwork';
+    public const PAYMENT_TYPE_ONCHAIN = 'OnChain';
+    public const PAYMENT_TYPE_LIGHTNING = 'LightningNetwork';
 
     abstract public function getPaymentMethods(string $storeId): array;
     abstract public function getPaymentMethod(string $storeId, string $cryptoCode);

--- a/src/Client/AbstractStorePaymentMethodClient.php
+++ b/src/Client/AbstractStorePaymentMethodClient.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Client;
 
-class AbstractStorePaymentMethodClient extends AbstractClient
+abstract class AbstractStorePaymentMethodClient extends AbstractClient
 {
+    abstract public function getPaymentMethods(string $storeId);
+    abstract public function getPaymentMethod(string $storeId, string $cryptoCode);
+    abstract public function updatePaymentMethod(string $storeId, string $cryptoCode, array $settings);
+    abstract public function removePaymentMethod(string $storeId, string $cryptoCode);
 }

--- a/src/Client/AbstractStorePaymentMethodClient.php
+++ b/src/Client/AbstractStorePaymentMethodClient.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Client;
+
+class AbstractStorePaymentMethodClient extends AbstractClient
+{
+}

--- a/src/Client/ApiKey.php
+++ b/src/Client/ApiKey.php
@@ -66,7 +66,7 @@ class ApiKey extends AbstractClient
      */
     public function getCurrent(): \BTCPayServer\Result\ApiKey
     {
-        $url = $this->getBaseUrl() . 'api-keys/current';
+        $url = $this->getApiUrl() . 'api-keys/current';
         $headers = $this->getRequestHeaders();
         $method = 'GET';
         $response = CurlClient::request($method, $url, $headers);

--- a/src/Client/Invoice.php
+++ b/src/Client/Invoice.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace BTCPayServer\Client;
 
 use BTCPayServer\Http\CurlClient;
-use BTCPayServer\Result\PaymentMethod;
 use BTCPayServer\Util\PreciseNumber;
 
 class Invoice extends AbstractClient
@@ -19,7 +18,7 @@ class Invoice extends AbstractClient
         ?array $metaData = null,
         ?InvoiceCheckoutOptions $checkoutOptions = null
     ): \BTCPayServer\Result\Invoice {
-        $url = $this->getBaseUrl() . 'stores/' . urlencode(
+        $url = $this->getApiUrl() . 'stores/' . urlencode(
             $storeId
         ) . '/invoices';
         $headers = $this->getRequestHeaders();
@@ -73,7 +72,7 @@ class Invoice extends AbstractClient
         string $storeId,
         string $invoiceId
     ): \BTCPayServer\Result\Invoice {
-        $url = $this->getBaseUrl() . 'stores/' . urlencode($storeId) . '/invoices/' . urlencode($invoiceId);
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/invoices/' . urlencode($invoiceId);
         $headers = $this->getRequestHeaders();
         $method = 'GET';
         $response = CurlClient::request($method, $url, $headers);
@@ -124,12 +123,12 @@ class Invoice extends AbstractClient
     }
 
     /**
-     * @return PaymentMethod[]
+     * @return \BTCPayServer\Result\InvoicePaymentMethod[]
      */
     public function getPaymentMethods(string $storeId, string $invoiceId): array
     {
         $method = 'GET';
-        $url = $this->getBaseUrl() . 'stores/' . urlencode($storeId) . '/invoices/' . urlencode($invoiceId) . '/payment-methods';
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/invoices/' . urlencode($invoiceId) . '/payment-methods';
         $headers = $this->getRequestHeaders();
         $response = CurlClient::request($method, $url, $headers);
 
@@ -142,7 +141,7 @@ class Invoice extends AbstractClient
                 JSON_THROW_ON_ERROR
             );
             foreach ($data as $item) {
-                $item = new \BTCPayServer\Result\PaymentMethod($item);
+                $item = new \BTCPayServer\Result\InvoicePaymentMethod($item);
                 $r[] = $item;
             }
             return $r;

--- a/src/Client/Store.php
+++ b/src/Client/Store.php
@@ -10,7 +10,7 @@ class Store extends AbstractClient
 {
     public function getStore($storeId): \BTCPayServer\Result\Store
     {
-        $url = $this->getBaseUrl() . 'stores/' . urlencode($storeId);
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId);
         $headers = $this->getRequestHeaders();
         $method = 'GET';
         $response = CurlClient::request($method, $url, $headers);
@@ -27,7 +27,7 @@ class Store extends AbstractClient
      */
     public function getStores(): array
     {
-        $url = $this->getBaseUrl() . 'stores';
+        $url = $this->getApiUrl() . 'stores';
         $headers = $this->getRequestHeaders();
         $method = 'GET';
         $response = CurlClient::request($method, $url, $headers);

--- a/src/Client/StorePaymentMethod.php
+++ b/src/Client/StorePaymentMethod.php
@@ -37,18 +37,20 @@ class StorePaymentMethod extends AbstractClient
     }
 
     /**
-     * @param string $storeId
-     * @param string $paymentMethod
-     *   Payment method e.g. BTC, BTC-LightningNetwork
-     * @param array  $settings
-     *   See updatePaymentMethod functions of StorePaymentMethodLightningNetwork
-     *   and StorePaymentMethodOnChain classes for what you can pass on each of
-     *   them.
+     * Updates OnChain or LightningNetwork payment methods. You can enable/disable
+     * them or change their settings.
      *
-     * @see StorePaymentMethodLightningNetwork::updatePaymentMethod()
-     * @see StorePaymentMethodOnChain::updatePaymentMethod()
+     * @param string $storeId
+     * @param string $paymentMethod Payment method e.g. BTC, BTC-LightningNetwork
+     * @param array $settings See updatePaymentMethod functions of
+     *                        StorePaymentMethodLightningNetwork and
+     *                        StorePaymentMethodOnChain classes for what you can
+     *                        pass on each of them.
      *
      * @return \BTCPayServer\Result\AbstractStorePaymentMethodResult
+     *
+     * @see StorePaymentMethodOnChain::updatePaymentMethod()
+     * @see StorePaymentMethodLightningNetwork::updatePaymentMethod()
      */
     public function updatePaymentMethod(string $storeId, string $paymentMethod, array $settings): \BTCPayServer\Result\AbstractStorePaymentMethodResult
     {
@@ -57,6 +59,15 @@ class StorePaymentMethod extends AbstractClient
         return $pmObject->updatePaymentMethod($storeId, $paymentType['code'], $settings);
     }
 
+    /**
+     * Disable the corresponding payment method. For OnChain payment methods
+     * this will also delete your configured xpub and/or hot wallet.
+     *
+     * @param string $storeId
+     * @param string $paymentMethod Payment method e.g. BTC, BTC-LightningNetwork
+     *
+     * @return bool
+     */
     public function removePaymentMethod(string $storeId, string $paymentMethod): bool
     {
         $paymentType = $this->determinePaymentType($paymentMethod);
@@ -67,8 +78,7 @@ class StorePaymentMethod extends AbstractClient
     /**
      * Helper function to extract cryptoCode and payment type from the string.
      *
-     * @param string $paymentMethod
-     *  Payment method e.g. BTC, BTC-LightningNetwork
+     * @param string $paymentMethod Payment method e.g. BTC, BTC-LightningNetwork
      *
      * @return array
      */

--- a/src/Client/StorePaymentMethod.php
+++ b/src/Client/StorePaymentMethod.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Client;
+
+use BTCPayServer\Http\CurlClient;
+use BTCPayServer\Client\StorePaymentMethodLightningNetwork;
+use BTCPayServer\Client\StorePaymentMethodOnChain;
+
+class StorePaymentMethod extends AbstractClient
+{
+    public function getPaymentMethods($storeId): array
+    {
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods';
+        $headers = $this->getRequestHeaders();
+        $method = 'GET';
+        $response = CurlClient::request($method, $url, $headers);
+
+        if ($response->getStatus() === 200) {
+            $pm = new \BTCPayServer\Result\StorePaymentMethodCollection(json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR));
+            return $pm->getPaymentMethods();
+        } else {
+            throw $this->getExceptionByStatusCode($method, $url, $response);
+        }
+    }
+
+    /**
+     * @param string $storeId
+     * @param string $paymentMethod
+     *  Payment method e.g. BTC, BTC-LightningNetwork
+     *
+     * @return mixed
+     */
+    public function getPaymentMethod(string $storeId, string $paymentMethod)
+    {
+        $paymentType = $this->determinePaymentType($paymentMethod);
+        $pmObject = $this->getInstance($paymentType['type']);
+        return $pmObject->getPaymentMethod($storeId, $paymentType['code']);
+    }
+
+    /**
+     * @param string $storeId
+     * @param string $paymentMethod
+     *   Payment method e.g. BTC, BTC-LightningNetwork
+     * @param array  $settings
+     *   See updatePaymentMethod functions of StorePaymentMethodLightningNetwork
+     *   and StorePaymentMethodOnChain classes for what you can pass on each of
+     *   them.
+     *
+     * @see StorePaymentMethodLightningNetwork::updatePaymentMethod()
+     * @see StorePaymentMethodOnChain::updatePaymentMethod()
+     *
+     * @return mixed
+     */
+    public function updatePaymentMethod(string $storeId, string $paymentMethod, array $settings)
+    {
+        $paymentType = $this->determinePaymentType($paymentMethod);
+        $pmObject = $this->getInstance($paymentType['type']);
+        return $pmObject->updatePaymentMethod($storeId, $paymentType['code'], $settings);
+    }
+
+    public function removePaymentMethod(string $storeId, string $paymentMethod)
+    {
+        $paymentType = $this->determinePaymentType($paymentMethod);
+        $pmObject = $this->getInstance($paymentType['type']);
+        return $pmObject->removePaymentMethod($storeId, $paymentType['code']);
+    }
+
+    /**
+     * Helper function to extract cryptoCode and payment type from the string.
+     *
+     * @param string $paymentMethod
+     *  Payment method e.g. BTC, BTC-LightningNetwork
+     *
+     * @return array
+     */
+    private function determinePaymentType(string $paymentMethod): array
+    {
+        $parts = explode('-', $paymentMethod, 2);
+
+        switch (count($parts)) {
+            case 1:
+                return [
+                  'code' => $parts[0],
+                  'type' => 'OnChain'
+                ];
+                break;
+            case 2:
+                return [
+                  'code' => $parts[0],
+                  'type' => $parts[1]
+                ];
+                break;
+            default:
+                return [];
+        }
+    }
+
+    /**
+     * Instantiate the needed payment class.
+     *
+     * @param $paymentType
+     *
+     * @return mixed
+     */
+    private function getInstance($paymentType)
+    {
+        $className = '\BTCPayServer\Client\StorePaymentMethod' . $paymentType;
+        return new $className($this->getBaseUrl(), $this->getApiKey());
+    }
+}

--- a/src/Client/StorePaymentMethodLightningNetwork.php
+++ b/src/Client/StorePaymentMethodLightningNetwork.php
@@ -13,9 +13,15 @@ use BTCPayServer\Http\CurlClient;
  */
 class StorePaymentMethodLightningNetwork extends AbstractStorePaymentMethodClient
 {
+    /**
+     * @param string $storeId
+     *
+     * @return  \BTCPayServer\Result\StorePaymentMethodLightningNetwork[]
+     * @throws \JsonException
+     */
     public function getPaymentMethods(string $storeId): array
     {
-        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/LightningNetwork';
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/' . self::PAYMENT_TYPE_LIGHTNING;
         $headers = $this->getRequestHeaders();
         $method = 'GET';
         $response = CurlClient::request($method, $url, $headers);
@@ -24,7 +30,7 @@ class StorePaymentMethodLightningNetwork extends AbstractStorePaymentMethodClien
             $r = [];
             $data = json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
             foreach ($data as $item) {
-                $r[] = new \BTCPayServer\Result\StorePaymentMethodLightningNetwork($item, $item['cryptoCode'] . '-LightningNetwork');
+                $r[] = new \BTCPayServer\Result\StorePaymentMethodLightningNetwork($item, $item['cryptoCode'] . '-' . self::PAYMENT_TYPE_LIGHTNING);
             }
             return $r;
         } else {
@@ -34,50 +40,61 @@ class StorePaymentMethodLightningNetwork extends AbstractStorePaymentMethodClien
 
     public function getPaymentMethod(string $storeId, string $cryptoCode): \BTCPayServer\Result\StorePaymentMethodLightningNetwork
     {
-        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/LightningNetwork/' . $cryptoCode;
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/' . self::PAYMENT_TYPE_LIGHTNING . '/' . $cryptoCode;
         $headers = $this->getRequestHeaders();
         $method = 'GET';
         $response = CurlClient::request($method, $url, $headers);
 
         if ($response->getStatus() === 200) {
             $data = json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
-            return new \BTCPayServer\Result\StorePaymentMethodLightningNetwork($data, $data['cryptoCode'] . '-LightningNetwork');
+            return new \BTCPayServer\Result\StorePaymentMethodLightningNetwork($data, $data['cryptoCode'] . '-' . self::PAYMENT_TYPE_LIGHTNING);
         } else {
             throw $this->getExceptionByStatusCode($method, $url, $response);
         }
     }
 
     /**
+     * Update LightningNetwork payment methods. Allows you to enable/disable
+     * them, and you can set the store LN node to be internal or some external
+     * node, see the Greenfield API docs for details.
+     *
      * @param string $storeId
      * @param string $cryptoCode
-     * @param array  $settings
-     *      Array of data to update. e.g.
-     *      [
-     *      'enabled' => true,
-     *      'connectionString' => 'Internal Node'
-     *      ]
+     * @param array $settings Array of data to update. e.g
+     *                        [
+     *                          'enabled' => true,
+     *                          'connectionString' => 'Internal Node'
+     *                        ]
      *
      * @return \BTCPayServer\Result\StorePaymentMethodLightningNetwork
      * @throws \JsonException
      */
     public function updatePaymentMethod(string $storeId, string $cryptoCode, array $settings): \BTCPayServer\Result\StorePaymentMethodLightningNetwork
     {
-        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/LightningNetwork/' . $cryptoCode;
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/' . self::PAYMENT_TYPE_LIGHTNING . '/' . $cryptoCode;
         $headers = $this->getRequestHeaders();
         $method = 'PUT';
         $response = CurlClient::request($method, $url, $headers, json_encode($settings));
 
         if ($response->getStatus() === 200) {
             $data = json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
-            return new \BTCPayServer\Result\StorePaymentMethodLightningNetwork($data, $data['cryptoCode'] . '-LightningNetwork');
+            return new \BTCPayServer\Result\StorePaymentMethodLightningNetwork($data, $data['cryptoCode'] . '-' . self::PAYMENT_TYPE_LIGHTNING);
         } else {
             throw $this->getExceptionByStatusCode($method, $url, $response);
         }
     }
 
+    /**
+     * Disables and removes the LightningNetwork payment method.
+     *
+     * @param string $storeId
+     * @param string $cryptoCode
+     *
+     * @return bool
+     */
     public function removePaymentMethod(string $storeId, string $cryptoCode): bool
     {
-        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/LightningNetwork/' . $cryptoCode;
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/' . self::PAYMENT_TYPE_LIGHTNING . '/' . $cryptoCode;
         $headers = $this->getRequestHeaders();
         $method = 'DELETE';
         $response = CurlClient::request($method, $url, $headers);

--- a/src/Client/StorePaymentMethodLightningNetwork.php
+++ b/src/Client/StorePaymentMethodLightningNetwork.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace BTCPayServer\Client;
 
 use BTCPayServer\Http\CurlClient;
-use BTCPayServer\Client\AbstractStorePaymentMethodClient;
 
 /**
  * Handles a stores LightningNetwork payment methods.

--- a/src/Client/StorePaymentMethodLightningNetwork.php
+++ b/src/Client/StorePaymentMethodLightningNetwork.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Client;
+
+use BTCPayServer\Http\CurlClient;
+
+/**
+ * Handles a stores LightningNetwork payment methods.
+ *
+ * @see https://docs.btcpayserver.org/API/Greenfield/v1/#tag/Store-Payment-Methods-(Lightning-Network)
+ */
+class StorePaymentMethodLightningNetwork extends AbstractClient
+{
+    public function getPaymentMethods(string $storeId): array
+    {
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/LightningNetwork';
+        $headers = $this->getRequestHeaders();
+        $method = 'GET';
+        $response = CurlClient::request($method, $url, $headers);
+
+        if ($response->getStatus() === 200) {
+            $r = [];
+            $data = json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+            foreach ($data as $item) {
+                $r[] = new \BTCPayServer\Result\StorePaymentMethodLightningNetwork($item, $item['cryptoCode'] . '-LightningNetwork');
+            }
+            return $r;
+        } else {
+            throw $this->getExceptionByStatusCode($method, $url, $response);
+        }
+    }
+
+    public function getPaymentMethod(string $storeId, string $cryptoCode): \BTCPayServer\Result\StorePaymentMethodLightningNetwork
+    {
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/LightningNetwork/' . $cryptoCode;
+        $headers = $this->getRequestHeaders();
+        $method = 'GET';
+        $response = CurlClient::request($method, $url, $headers);
+
+        if ($response->getStatus() === 200) {
+            $data = json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+            return new \BTCPayServer\Result\StorePaymentMethodLightningNetwork($data, $data['cryptoCode'] . '-LightningNetwork');
+        } else {
+            throw $this->getExceptionByStatusCode($method, $url, $response);
+        }
+    }
+
+    /**
+     * @param string $storeId
+     * @param string $cryptoCode
+     * @param array  $settings
+     *      Array of data to update. e.g.
+     *      [
+     *      'enabled' => true,
+     *      'connectionString' => 'Internal Node'
+     *      ]
+     *
+     * @return \BTCPayServer\Result\StorePaymentMethodLightningNetwork
+     * @throws \JsonException
+     */
+    public function updatePaymentMethod(string $storeId, string $cryptoCode, array $settings): \BTCPayServer\Result\StorePaymentMethodLightningNetwork
+    {
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/LightningNetwork/' . $cryptoCode;
+        $headers = $this->getRequestHeaders();
+        $method = 'PUT';
+        $response = CurlClient::request($method, $url, $headers, json_encode($settings));
+
+        if ($response->getStatus() === 200) {
+            $data = json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+            return new \BTCPayServer\Result\StorePaymentMethodLightningNetwork($data, $data['cryptoCode'] . '-LightningNetwork');
+        } else {
+            throw $this->getExceptionByStatusCode($method, $url, $response);
+        }
+    }
+
+    public function removePaymentMethod(string $storeId, string $cryptoCode): bool
+    {
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/LightningNetwork/' . $cryptoCode;
+        $headers = $this->getRequestHeaders();
+        $method = 'DELETE';
+        $response = CurlClient::request($method, $url, $headers);
+
+        if ($response->getStatus() === 200) {
+            return true;
+        } else {
+            throw $this->getExceptionByStatusCode($method, $url, $response);
+        }
+    }
+}

--- a/src/Client/StorePaymentMethodLightningNetwork.php
+++ b/src/Client/StorePaymentMethodLightningNetwork.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace BTCPayServer\Client;
 
 use BTCPayServer\Http\CurlClient;
+use BTCPayServer\Client\AbstractStorePaymentMethodClient;
 
 /**
  * Handles a stores LightningNetwork payment methods.
  *
  * @see https://docs.btcpayserver.org/API/Greenfield/v1/#tag/Store-Payment-Methods-(Lightning-Network)
  */
-class StorePaymentMethodLightningNetwork extends AbstractClient
+class StorePaymentMethodLightningNetwork extends AbstractStorePaymentMethodClient
 {
     public function getPaymentMethods(string $storeId): array
     {

--- a/src/Client/StorePaymentMethodOnChain.php
+++ b/src/Client/StorePaymentMethodOnChain.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace BTCPayServer\Client;
 
 use BTCPayServer\Http\CurlClient;
+use BTCPayServer\Client\AbstractStorePaymentMethodClient;
 
 /**
  * Handles stores on chain payment methods.
  *
  * @see https://docs.btcpayserver.org/API/Greenfield/v1/#tag/Store-Payment-Methods-(On-Chain)
  */
-class StorePaymentMethodOnChain extends AbstractClient
+class StorePaymentMethodOnChain extends AbstractStorePaymentMethodClient
 {
     public function getPaymentMethods(string $storeId): array
     {

--- a/src/Client/StorePaymentMethodOnChain.php
+++ b/src/Client/StorePaymentMethodOnChain.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace BTCPayServer\Client;
 
 use BTCPayServer\Http\CurlClient;
-use BTCPayServer\Client\AbstractStorePaymentMethodClient;
 
 /**
  * Handles stores on chain payment methods.
@@ -93,19 +92,18 @@ class StorePaymentMethodOnChain extends AbstractStorePaymentMethodClient
 
         if ($response->getStatus() === 200) {
             return json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
-            //return new \BTCPayServer\Result\StorePaymentMethodLightning(json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR));
+        //return new \BTCPayServer\Result\StorePaymentMethodLightning(json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR));
         } else {
             throw $this->getExceptionByStatusCode($method, $url, $response);
         }
     }
 
     public function previewProposedPaymentMethodAddresses(
-      string $storeId,
-      string $cryptoCode,
-      string $derivationScheme,
-      string $accountKeyPath = null
-    ): array
-    {
+        string $storeId,
+        string $cryptoCode,
+        string $derivationScheme,
+        string $accountKeyPath = null
+    ): array {
         // todo: add offset + amount query parameters + check structure of derivationScheme etc.
 
         $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/OnChain/' . $cryptoCode . '/preview';

--- a/src/Client/StorePaymentMethodOnChain.php
+++ b/src/Client/StorePaymentMethodOnChain.php
@@ -13,7 +13,6 @@ use BTCPayServer\Http\CurlClient;
  */
 class StorePaymentMethodOnChain extends AbstractStorePaymentMethodClient
 {
-
     /**
      * @param string $storeId
      *
@@ -107,7 +106,7 @@ class StorePaymentMethodOnChain extends AbstractStorePaymentMethodClient
 
         if ($response->getStatus() === 200) {
             $addressList = new \BTCPayServer\Result\AddressList(
-              json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR)
+                json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR)
             );
             return $addressList->getAddresses();
         } else {
@@ -149,7 +148,7 @@ class StorePaymentMethodOnChain extends AbstractStorePaymentMethodClient
 
         if ($response->getStatus() === 200) {
             $addressList = new \BTCPayServer\Result\AddressList(
-              json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR)
+                json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR)
             );
             return $addressList->getAddresses();
         } else {

--- a/src/Client/StorePaymentMethodOnChain.php
+++ b/src/Client/StorePaymentMethodOnChain.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Client;
+
+use BTCPayServer\Http\CurlClient;
+
+/**
+ * Handles stores on chain payment methods.
+ *
+ * @see https://docs.btcpayserver.org/API/Greenfield/v1/#tag/Store-Payment-Methods-(On-Chain)
+ */
+class StorePaymentMethodOnChain extends AbstractClient
+{
+    public function getPaymentMethods(string $storeId): array
+    {
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/OnChain';
+        $headers = $this->getRequestHeaders();
+        $method = 'GET';
+        $response = CurlClient::request($method, $url, $headers);
+
+        if ($response->getStatus() === 200) {
+            $r = [];
+            $data = json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+            foreach ($data as $item) {
+                $r[] = new \BTCPayServer\Result\StorePaymentMethodOnChain($item, $item['cryptoCode']);
+            }
+            return $r;
+        } else {
+            throw $this->getExceptionByStatusCode($method, $url, $response);
+        }
+    }
+
+    public function getPaymentMethod(string $storeId, string $cryptoCode): \BTCPayServer\Result\StorePaymentMethodOnChain
+    {
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/OnChain/' . $cryptoCode;
+        $headers = $this->getRequestHeaders();
+        $method = 'GET';
+        $response = CurlClient::request($method, $url, $headers);
+
+        if ($response->getStatus() === 200) {
+            $data = json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+            return new \BTCPayServer\Result\StorePaymentMethodOnChain($data, $data['cryptoCode']);
+        } else {
+            throw $this->getExceptionByStatusCode($method, $url, $response);
+        }
+    }
+
+    /**
+     * Update a payment method.
+     *
+     * @param string $storeId
+     * @param string $cryptoCode
+     *
+     * @param array $settings
+     *  Array of data to update. e.g.
+     *    [
+     *      'enabled' => true,
+     *      'derivationScheme' => 'xpub...',
+     *      'label' => 'string',
+     *      'accountKeyPath' => "abcd82a1/84'/0'/0'"
+     *    ]
+     *
+     * @return \BTCPayServer\Result\StorePaymentMethodOnChain
+     * @throws \JsonException
+     *
+     */
+    public function updatePaymentMethod(string $storeId, string $cryptoCode, array $settings): \BTCPayServer\Result\StorePaymentMethodOnChain
+    {
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/OnChain/' . $cryptoCode;
+        $headers = $this->getRequestHeaders();
+        $method = 'PUT';
+        $response = CurlClient::request($method, $url, $headers, json_encode($settings));
+
+        if ($response->getStatus() === 200) {
+            $data = json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+            return new \BTCPayServer\Result\StorePaymentMethodOnChain($data, $data['cryptoCode']);
+        } else {
+            throw $this->getExceptionByStatusCode($method, $url, $response);
+        }
+    }
+
+    public function previewPaymentMethodAddresses(string $storeId, string $cryptoCode): array
+    {
+        // todo: add offset + amount query parameters
+
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/OnChain/' . $cryptoCode . '/preview';
+        $headers = $this->getRequestHeaders();
+        $method = 'GET';
+        $response = CurlClient::request($method, $url, $headers);
+
+        if ($response->getStatus() === 200) {
+            return json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+            //return new \BTCPayServer\Result\StorePaymentMethodLightning(json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR));
+        } else {
+            throw $this->getExceptionByStatusCode($method, $url, $response);
+        }
+    }
+
+    public function previewProposedPaymentMethodAddresses(
+      string $storeId,
+      string $cryptoCode,
+      string $derivationScheme,
+      string $accountKeyPath = null
+    ): array
+    {
+        // todo: add offset + amount query parameters + check structure of derivationScheme etc.
+
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/OnChain/' . $cryptoCode . '/preview';
+        $headers = $this->getRequestHeaders();
+        $method = 'POST';
+        $body = json_encode([
+              'derivationScheme' => $derivationScheme,
+              'accountKeyPath' => $accountKeyPath,
+        ]);
+        $response = CurlClient::request($method, $url, $headers, $body);
+
+        if ($response->getStatus() === 200) {
+            // todo: return list of addresses array
+            return json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        } else {
+            throw $this->getExceptionByStatusCode($method, $url, $response);
+        }
+    }
+
+    public function removePaymentMethod(string $storeId, string $cryptoCode): bool
+    {
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/payment-methods/OnChain/' . $cryptoCode;
+        $headers = $this->getRequestHeaders();
+        $method = 'DELETE';
+        $response = CurlClient::request($method, $url, $headers);
+
+        if ($response->getStatus() === 200) {
+            return true;
+        } else {
+            throw $this->getExceptionByStatusCode($method, $url, $response);
+        }
+    }
+}

--- a/src/Client/StorePaymentMethodOnChain.php
+++ b/src/Client/StorePaymentMethodOnChain.php
@@ -91,8 +91,8 @@ class StorePaymentMethodOnChain extends AbstractStorePaymentMethodClient
         $response = CurlClient::request($method, $url, $headers);
 
         if ($response->getStatus() === 200) {
+            // todo: return list of addresses objects array
             return json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
-        //return new \BTCPayServer\Result\StorePaymentMethodLightning(json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR));
         } else {
             throw $this->getExceptionByStatusCode($method, $url, $response);
         }
@@ -116,7 +116,7 @@ class StorePaymentMethodOnChain extends AbstractStorePaymentMethodClient
         $response = CurlClient::request($method, $url, $headers, $body);
 
         if ($response->getStatus() === 200) {
-            // todo: return list of addresses array
+            // todo: return list of addresses objects array
             return json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
         } else {
             throw $this->getExceptionByStatusCode($method, $url, $response);

--- a/src/Client/Webhook.php
+++ b/src/Client/Webhook.php
@@ -15,7 +15,7 @@ class Webhook extends AbstractClient
     public function getWebhooks(string $storeId): array
     {
         // TODO test & finish
-        $url = $this->getBaseUrl() . 'stores/' . urlencode($storeId) . '/webhooks';
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/webhooks';
         $headers = $this->getRequestHeaders();
         $method = 'GET';
         $response = CurlClient::request($method, $url, $headers);
@@ -61,7 +61,7 @@ class Webhook extends AbstractClient
             $data['secret'] = $secret;
         }
 
-        $url = $this->getBaseUrl() . 'stores/' . urlencode($storeId) . '/webhooks';
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/webhooks';
         $headers = $this->getRequestHeaders();
         $method = 'GET';
         $response = CurlClient::request($method, $url, $headers, json_encode($data, JSON_THROW_ON_ERROR));

--- a/src/Result/AbstractStorePaymentMethodResult.php
+++ b/src/Result/AbstractStorePaymentMethodResult.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Result;
+
+abstract class AbstractStorePaymentMethodResult extends AbstractResult
+{
+    public function __construct(array $data, string $paymentMethod = null)
+    {
+        // Temporary workaround until the api provides paymentMethod.
+        if (!isset($data['paymentMethod'])) {
+            $data['paymentMethod'] = $paymentMethod;
+        }
+
+        parent::__construct($data);
+    }
+}

--- a/src/Result/Address.php
+++ b/src/Result/Address.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Result;
+
+class Address extends AbstractResult
+{
+}

--- a/src/Result/AddressList.php
+++ b/src/Result/AddressList.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Result;
+
+class AddressList extends \BTCPayServer\Result\AbstractListResult
+{
+    /**
+     * @return \BTCPayServer\Result\Address[]
+     */
+    public function getAddresses(): array
+    {
+        $r = [];
+        foreach ($this->getData()['addresses'] as $addressData) {
+            $r[] = new \BTCPayServer\Result\Address($addressData);
+        }
+        return $r;
+    }
+}

--- a/src/Result/InvoicePaymentMethod.php
+++ b/src/Result/InvoicePaymentMethod.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Result;
 
-class PaymentMethod extends AbstractResult
+class InvoicePaymentMethod extends AbstractResult
 {
 }

--- a/src/Result/StorePaymentMethodCollection.php
+++ b/src/Result/StorePaymentMethodCollection.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Result;
+
+class StorePaymentMethodCollection extends AbstractListResult
+{
+    public function getPaymentMethods(): array
+    {
+        $r = [];
+        foreach ($this->getData() as $paymentMethod => $paymentMethodData) {
+            // Consistency: Flatten the array to be consistent with the specific
+            // payment method endpoints.
+            $paymentMethodData += $paymentMethodData['data'];
+            unset($paymentMethodData['data']);
+
+            if (strpos($paymentMethod, 'LightningNetwork') !== false) {
+                // Consistency: Add back the cryptoCode missing on this endpoint
+                // results until it is there.
+                if (!isset($paymentMethodData['cryptoCode'])) {
+                    $paymentMethodData['cryptoCode'] = str_replace('-LightningNetwork', '', $paymentMethod);
+                }
+                $r[] = new \BTCPayServer\Result\StorePaymentMethodLightningNetwork($paymentMethodData, $paymentMethod);
+            } else {
+                // Consistency: Add back the cryptoCode missing on this endpoint
+                // results until it is there.
+                if (!isset($paymentMethodData['cryptoCode'])) {
+                    $paymentMethodData['cryptoCode'] = $paymentMethod;
+                }
+                $r[] = new \BTCPayServer\Result\StorePaymentMethodOnChain($paymentMethodData, $paymentMethod);
+            }
+        }
+        return $r;
+    }
+}

--- a/src/Result/StorePaymentMethodCollection.php
+++ b/src/Result/StorePaymentMethodCollection.php
@@ -6,7 +6,6 @@ namespace BTCPayServer\Result;
 
 class StorePaymentMethodCollection extends AbstractListResult
 {
-
     /**
      * @return \BTCPayServer\Result\AbstractStorePaymentMethodResult[]
      */

--- a/src/Result/StorePaymentMethodCollection.php
+++ b/src/Result/StorePaymentMethodCollection.php
@@ -6,6 +6,10 @@ namespace BTCPayServer\Result;
 
 class StorePaymentMethodCollection extends AbstractListResult
 {
+
+    /**
+     * @return \BTCPayServer\Result\AbstractStorePaymentMethodResult[]
+     */
     public function getPaymentMethods(): array
     {
         $r = [];

--- a/src/Result/StorePaymentMethodLightningNetwork.php
+++ b/src/Result/StorePaymentMethodLightningNetwork.php
@@ -4,15 +4,6 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Result;
 
-class StorePaymentMethodLightningNetwork extends AbstractResult
+class StorePaymentMethodLightningNetwork extends AbstractStorePaymentMethodResult
 {
-    public function __construct(array $data, $paymentMethod = null)
-    {
-        // Temporary workaround until the api provides paymentMethod.
-        if (!isset($data['paymentMethod'])) {
-            $data['paymentMethod'] = $paymentMethod;
-        }
-
-        parent::__construct($data);
-    }
 }

--- a/src/Result/StorePaymentMethodLightningNetwork.php
+++ b/src/Result/StorePaymentMethodLightningNetwork.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Result;
+
+class StorePaymentMethodLightningNetwork extends AbstractResult
+{
+    public function __construct(array $data, $paymentMethod = null)
+    {
+        // Temporary workaround until the api provides paymentMethod.
+        if (!isset($data['paymentMethod'])) {
+            $data['paymentMethod'] = $paymentMethod;
+        }
+
+        parent::__construct($data);
+    }
+}

--- a/src/Result/StorePaymentMethodOnChain.php
+++ b/src/Result/StorePaymentMethodOnChain.php
@@ -4,15 +4,6 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Result;
 
-class StorePaymentMethodOnChain extends AbstractResult
+class StorePaymentMethodOnChain extends AbstractStorePaymentMethodResult
 {
-    public function __construct(array $data, $paymentMethod = null)
-    {
-        // Temporary workaround until the api provides paymentMethod.
-        if (!isset($data['paymentMethod'])) {
-            $data['paymentMethod'] = $paymentMethod;
-        }
-
-        parent::__construct($data);
-    }
 }

--- a/src/Result/StorePaymentMethodOnChain.php
+++ b/src/Result/StorePaymentMethodOnChain.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Result;
+
+class StorePaymentMethodOnChain extends AbstractResult
+{
+    public function __construct(array $data, $paymentMethod = null)
+    {
+        // Temporary workaround until the api provides paymentMethod.
+        if (!isset($data['paymentMethod'])) {
+            $data['paymentMethod'] = $paymentMethod;
+        }
+
+        parent::__construct($data);
+    }
+}


### PR DESCRIPTION
Finally had time to finish this. Lots of things going on. Main interesting thing maybe is that I made sure that the global payment method endpoint data is the same like the specific onchain and LN endpoints. This means flattened the dataset and added `cryptoCode` which is missing from the global endpoint, see https://github.com/btcpayserver/btcpayserver/issues/2855

Also I added `paymentMethod` so it can be used right away in invoices without needing to assemble the string consumer side, see here https://github.com/btcpayserver/btcpayserver/issues/2854