### PR TITLE
Refactored exceptions so pre-request errors can be caught (i.e. bad SSL certificate)

### DIFF
--- a/src/Client/AbstractClient.php
+++ b/src/Client/AbstractClient.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace BTCPayServer\Client;
 
 use BTCPayServer\Exception\BadRequestException;
-use BTCPayServer\Exception\BTCPayException;
 use BTCPayServer\Exception\ForbiddenException;
+use BTCPayServer\Exception\RequestException;
 use BTCPayServer\Http\Response;
 
 class AbstractClient
@@ -52,13 +52,13 @@ class AbstractClient
         string $method,
         string $url,
         Response $response
-    ): BTCPayException {
+    ): RequestException {
         $exceptions = [
             ForbiddenException::STATUS => ForbiddenException::class,
             BadRequestException::STATUS => BadRequestException::class,
         ];
 
-        $class = $exceptions[$response->getStatus()] ?? BTCPayException::class;
+        $class = $exceptions[$response->getStatus()] ?? RequestException::class;
         $e = new $class($method, $url, $response);
         return $e;
     }

--- a/src/Client/ApiKey.php
+++ b/src/Client/ApiKey.php
@@ -56,7 +56,7 @@ class ApiKey extends AbstractClient
         $queryParams = implode("&", $queryParams);
 
 
-        $url = $url . '?' . $queryParams;
+        $url .= '?' . $queryParams;
 
         return $url;
     }

--- a/src/Exception/BTCPayException.php
+++ b/src/Exception/BTCPayException.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Exception;
 
-use BTCPayServer\Http\ResponseInterface;
-
 class BTCPayException extends \RuntimeException
 {
-    public function __construct(string $method, string $url, ResponseInterface $response)
+    public function __construct(string $message, int $code, \Throwable $previous = null)
     {
-        $message = 'Error during ' . $method . ' to ' . $url . '. Got response (' . $response->getStatus() . '): ' . $response->getBody();
-        parent::__construct($message, $response->getStatus());
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Exception/BadRequestException.php
+++ b/src/Exception/BadRequestException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Exception;
 
-class BadRequestException extends BTCPayException
+class BadRequestException extends RequestException
 {
     public const STATUS = 400;
 }

--- a/src/Exception/ConnectException.php
+++ b/src/Exception/ConnectException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Exception;
+
+class ConnectException extends BTCPayException
+{
+    public function __construct(string $curlErrorMessage, int $curlErrorCode)
+    {
+        parent::__construct($curlErrorMessage, $curlErrorCode);
+    }
+}

--- a/src/Exception/ForbiddenException.php
+++ b/src/Exception/ForbiddenException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Exception;
 
-class ForbiddenException extends BTCPayException
+class ForbiddenException extends RequestException
 {
     public const STATUS = 403;
 }

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Exception;
+
+use BTCPayServer\Http\ResponseInterface;
+
+class RequestException extends BTCPayException
+{
+    public function __construct(string $method, string $url, ResponseInterface $response)
+    {
+        $message = 'Error during ' . $method . ' to ' . $url . '. Got response (' . $response->getStatus() . '): ' . $response->getBody();
+        parent::__construct($message, $response->getStatus());
+    }
+}

--- a/src/Http/ClientInterface.php
+++ b/src/Http/ClientInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Http;
 
+use BTCPayServer\Exception\ConnectException;
+use BTCPayServer\Exception\RequestException;
+
 interface ClientInterface
 {
     /**
@@ -14,7 +17,10 @@ interface ClientInterface
      * @param array  $headers
      * @param string $body
      *
-     * @return \BTCPayServer\Http\ResponseInterface
+     * @throws ConnectException
+     * @throws RequestException
+     *
+     * @return ResponseInterface
      */
     public static function request(string $method, string $url, array $headers = [], string $body = ''): ResponseInterface;
 }

--- a/src/Http/CurlClient.php
+++ b/src/Http/CurlClient.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Http;
 
+use BTCPayServer\Exception\ConnectException;
+
 /**
  * HTTP Client using cURL to communicate.
  */
@@ -15,7 +17,7 @@ class CurlClient implements ClientInterface
     public static function request(
         string $method,
         string $url,
-        array $headers = [],
+        array  $headers = [],
         string $body = ''
     ): ResponseInterface {
         $flatHeaders = [];
@@ -34,6 +36,7 @@ class CurlClient implements ClientInterface
         curl_setopt($ch, CURLOPT_HTTPHEADER, $flatHeaders);
 
         $response = curl_exec($ch);
+
         $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
 
@@ -58,6 +61,10 @@ class CurlClient implements ClientInterface
                     }
                 }
             }
+        } else {
+            $errorMessage = curl_error($ch);
+            $errorCode = curl_errno($ch);
+            throw new ConnectException($errorMessage, $errorCode);
         }
 
         return new Response($status, $responseBody, $responseHeaders);


### PR DESCRIPTION
The existing BTCPayException was renamed to RequestException.
A new ConnectException is for errors that can happen before the request itself.
There is a new BTCPayException class that is the parent of both.
And some minor cleanup.