### PR TITLE
Fixed 2 cases where the getBaseUrl() was still used

### DIFF
--- a/src/Client/Invoice.php
+++ b/src/Client/Invoice.php
@@ -99,7 +99,7 @@ class Invoice extends AbstractClient
         string $storeId,
         array $filterByOrderIds = null
     ): \BTCPayServer\Result\InvoiceList {
-        $url = $this->getBaseUrl() . 'stores/' . urlencode($storeId) . '/invoices?';
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/invoices?';
         if ($filterByOrderIds !== null) {
             foreach ($filterByOrderIds as $filterByOrderId) {
                 $url .= 'orderId=' . urlencode($filterByOrderId) . '&';
@@ -153,7 +153,7 @@ class Invoice extends AbstractClient
 
     public function markInvoiceStatus(string $storeId, string $invoiceId, string $markAs): \BTCPayServer\Result\Invoice
     {
-        $url = $this->getBaseUrl() . 'stores/' . urlencode(
+        $url = $this->getApiUrl() . 'stores/' . urlencode(
             $storeId
         ) . '/invoices/' . urlencode($invoiceId) . '/status';
         $headers = $this->getRequestHeaders();

--- a/src/Client/Webhook.php
+++ b/src/Client/Webhook.php
@@ -93,7 +93,7 @@ class Webhook extends AbstractClient
 
     public function deleteWebhook(string $storeId, string $webhookId)
     {
-        $url = $this->getBaseUrl() . 'stores/' . urlencode($storeId) . '/webhooks/' . urlencode($webhookId);
+        $url = $this->getApiUrl() . 'stores/' . urlencode($storeId) . '/webhooks/' . urlencode($webhookId);
         $headers = $this->getRequestHeaders();
         $method = 'DELETE';
         $response = CurlClient::request($method, $url, $headers);


### PR DESCRIPTION
The PHP lib tried to connect to the wrong URL. The string `/api/v1/` was missing.