### PR TITLE
Allow curl_options to be set for CurlClient

### DIFF
--- a/src/Http/CurlClient.php
+++ b/src/Http/CurlClient.php
@@ -11,16 +11,30 @@ use BTCPayServer\Exception\ConnectException;
  */
 class CurlClient implements ClientInterface
 {
+    protected $curl_options = [];
+
     /**
-     * Override this method if you need to set any special parameters like disable CURLOPT_SSL_VERIFYHOST and CURLOPT_SSL_VERIFYPEER.
+     * Inits curl session adding any additional curl options set.
      * @return false|resource
      */
     protected function initCurl()
     {
         // We cannot set a return type here as it is "resource" for PHP < 8 and CurlHandle for PHP >= 8.
-        return curl_init();
+        $ch = curl_init();
+        if ($ch && count($this->curl_options)) {
+            curl_setopt_array($ch, $this->curl_options);
+        }
+        return $ch;
     }
 
+    /**
+     * Use this method if you need to set any special parameters like disable CURLOPT_SSL_VERIFYHOST and CURLOPT_SSL_VERIFYPEER.
+     * @return void
+     */
+    public function setCurlOptions(array $options)
+    {
+        $this->curl_options = $options;
+    }
 
     /**
      * @inheritdoc

--- a/src/Http/CurlClient.php
+++ b/src/Http/CurlClient.php
@@ -11,7 +11,7 @@ use BTCPayServer\Exception\ConnectException;
  */
 class CurlClient implements ClientInterface
 {
-    protected $curl_options = [];
+    protected $curlOptions = [];
 
     /**
      * Inits curl session adding any additional curl options set.
@@ -21,8 +21,8 @@ class CurlClient implements ClientInterface
     {
         // We cannot set a return type here as it is "resource" for PHP < 8 and CurlHandle for PHP >= 8.
         $ch = curl_init();
-        if ($ch && count($this->curl_options)) {
-            curl_setopt_array($ch, $this->curl_options);
+        if ($ch && count($this->curlOptions)) {
+            curl_setopt_array($ch, $this->curlOptions);
         }
         return $ch;
     }
@@ -33,7 +33,7 @@ class CurlClient implements ClientInterface
      */
     public function setCurlOptions(array $options)
     {
-        $this->curl_options = $options;
+        $this->curlOptions = $options;
     }
 
     /**


### PR DESCRIPTION
I know this was addressed in 
https://github.com/btcpayserver/btcpayserver-greenfield-php/pull/24

However now that a ClientInterface can be passed to a Client constructor, we have the opportunity to pass a CurlClient instance with custom curl_options. 

Considering the primary use case for this feature is SSL override in localised dev environments, it is annoying to have to bolt on an overriding class to allow requests to function.

This pull request allows us to install the package with composer and run the following test without having to load in any external/custom classes.

```
require __DIR__ . '/vendor/autoload.php';

use BTCPayServer\Http\CurlClient;
use BTCPayServer\Client\Store;

$apiKey = APIKEY
$host = HOST
$storeId = STOREID

// Init CURL client for local testing
$curlClient = new CurlClient();
$curlClient->setCurlOptions([
    CURLOPT_SSL_VERIFYHOST => false,
    CURLOPT_SSL_VERIFYPEER => false,
]);

// Get store info from BTCPay Server.
$client = new Store( $host, $apiKey, $curlClient );
var_dump( $client->getStore( $storeId ) );
```

