### PR TITLE
Added WebhookCreated for `createWebhook` 

### DIFF
--- a/src/Client/Webhook.php
+++ b/src/Client/Webhook.php
@@ -118,7 +118,7 @@ class Webhook extends AbstractClient
         }
     }
 
-    public function createWebhook(string $storeId, string $url, ?array $specificEvents, ?string $secret): \BTCPayServer\Result\Webhook
+    public function createWebhook(string $storeId, string $url, ?array $specificEvents, ?string $secret): \BTCPayServer\Result\WebhookCreated
     {
         $data = [
             'enabled' => true,
@@ -152,7 +152,7 @@ class Webhook extends AbstractClient
 
         if ($response->getStatus() === 200) {
             $data = json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
-            return new \BTCPayServer\Result\Webhook($data);
+            return new \BTCPayServer\Result\WebhookCreated($data);
         } else {
             throw $this->getExceptionByStatusCode($method, $url, $response);
         }

--- a/src/Result/WebhookCreated.php
+++ b/src/Result/WebhookCreated.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Result;
+
+class WebhookCreated extends Webhook
+{
+    public function getSecret(): string
+    {
+        $data = $this->getData();
+        return $data['secret'];
+    }
+}


### PR DESCRIPTION
Created a new class called `WebhookCreated ` that implements the `Webhook` class, but adds a `secret`-function as that was missing. Since we return a new class that implements the old class, this shouldn't break backwards compatibility.

I've tested it on my local webstore and it works as expected.