### PR TITLE
Lightning Endpoints, PSR-4 Autoloading, UTXO GetAddress()

### DIFF
--- a/examples/miscellaneous.php
+++ b/examples/miscellaneous.php
@@ -15,11 +15,11 @@ class Misc
         $this->host = '';
     }
 
-    public function getPermissionsMetadata()
+    public function getPermissionMetadata()
     {
         try {
             $client = new Miscellaneous($this->host, $this->apiKey);
-            var_dump($client->getPermissionsMetadata());
+            var_dump($client->getPermissionMetadata());
         } catch (\Throwable $e) {
             echo "Error: " . $e->getMessage();
         }
@@ -50,6 +50,6 @@ class Misc
 }
 
 $misc = new Misc();
-//$misc->getPermissionsMetadata();
+//$misc->getPermissionMetadata();
 //$misc->getLanguageCodes();
 //$misc->getInvoiceCheckout();

--- a/src/Client/LightningInternalNode.php
+++ b/src/Client/LightningInternalNode.php
@@ -27,7 +27,7 @@ class LightningInternalNode extends AbstractClient
 
     public function connectToLightningNode(string $cryptoCode, ?string $nodeURI): bool
     {
-        $url = $this->getApiUrl() . 'server/lightning' .
+        $url = $this->getApiUrl() . 'server/lightning/' .
                     urlencode($cryptoCode) . '/connect';
 
         $headers = $this->getRequestHeaders();
@@ -74,7 +74,7 @@ class LightningInternalNode extends AbstractClient
         string $channelAmount,
         int $feeRate
     ): bool {
-        $url = $this->getApiUrl() . 'server/lightning' .
+        $url = $this->getApiUrl() . 'server/lightning/' .
                     urlencode($cryptoCode) . '/channels';
 
         $headers = $this->getRequestHeaders();
@@ -135,7 +135,7 @@ class LightningInternalNode extends AbstractClient
 
     public function payLightningInvoice(string $cryptoCode, string $BOLT11): bool
     {
-        $url = $this->getApiUrl() . 'server/lightning' .
+        $url = $this->getApiUrl() . 'server/lightning/' .
                     urlencode($cryptoCode) . '/invoices/pay';
 
         $headers = $this->getRequestHeaders();
@@ -170,7 +170,7 @@ class LightningInternalNode extends AbstractClient
         ?string $description = null,
         ?bool $privateRouteHints = false
     ): \BTCPayServer\Result\Invoice {
-        $url = $this->getApiUrl() . 'server/lightning' .
+        $url = $this->getApiUrl() . 'server/lightning/' .
                     urlencode($cryptoCode) . '/invoices';
 
         $headers = $this->getRequestHeaders();

--- a/src/Client/Miscellaneous.php
+++ b/src/Client/Miscellaneous.php
@@ -6,7 +6,7 @@ namespace BTCPayServer\Client;
 
 class Miscellaneous extends AbstractClient
 {
-    public function getPermissionsMetadata(): \BTCPayServer\Result\PermissionsMetaData
+    public function getPermissionMetadata(): \BTCPayServer\Result\PermissionMetaData
     {
         $url = $this->getBaseUrl() . '/misc/permissions';
         $headers = $this->getRequestHeaders();
@@ -15,7 +15,7 @@ class Miscellaneous extends AbstractClient
         $response = $this->getHttpClient()->request($method, $url, $headers);
 
         if ($response->getStatus() === 200) {
-            return new \BTCPayServer\Result\PermissionsMetaData(
+            return new \BTCPayServer\Result\PermissionMetaData(
                 json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR)
             );
         } else {

--- a/src/Client/Miscellaneous.php
+++ b/src/Client/Miscellaneous.php
@@ -6,7 +6,7 @@ namespace BTCPayServer\Client;
 
 class Miscellaneous extends AbstractClient
 {
-    public function getPermissionMetadata(): \BTCPayServer\Result\PermissionMetaData
+    public function getPermissionMetadata(): \BTCPayServer\Result\PermissionMetadata
     {
         $url = $this->getBaseUrl() . '/misc/permissions';
         $headers = $this->getRequestHeaders();
@@ -15,7 +15,7 @@ class Miscellaneous extends AbstractClient
         $response = $this->getHttpClient()->request($method, $url, $headers);
 
         if ($response->getStatus() === 200) {
-            return new \BTCPayServer\Result\PermissionMetaData(
+            return new \BTCPayServer\Result\PermissionMetadata(
                 json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR)
             );
         } else {

--- a/src/Result/PermissionMetadata.php
+++ b/src/Result/PermissionMetadata.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Result;
 
-class PermissionMetaData extends AbstractResult
+class PermissionMetadata extends AbstractResult
 {
     public function getName(): string
     {

--- a/src/Result/PermissionMetadata.php
+++ b/src/Result/PermissionMetadata.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Result;
 
-class PermissionsMetaData extends AbstractResult
+class PermissionMetaData extends AbstractResult
 {
     public function getName(): string
     {

--- a/src/Result/StoreOnChainWalletUTXO.php
+++ b/src/Result/StoreOnChainWalletUTXO.php
@@ -44,10 +44,10 @@ class StoreOnChainWalletUTXO extends AbstractResult
         return $data['keyPath'];
     }
 
-    public function getAddress(): Address
+    public function getAddress(): string
     {
         $data = $this->getData();
-        return new Address($data['address']);
+        return $data['address'];
     }
 
     public function getConfirmations(): int


### PR DESCRIPTION
Discovered a few bugs in lightning endpoints and resolving issue #54 and #53 .

- Lightning Internal Node methods missing trailing slash, resulting in 404 api calls.
- PSR-4 autoloading failed due to camel case.
- UTXO getAddress was returning an object when string was expected. Changed to string. 