### PR TITLE
Add undocumented param secret to workaround BTCPay Server bug.

### DIFF
--- a/src/Client/Webhook.php
+++ b/src/Client/Webhook.php
@@ -164,18 +164,31 @@ class Webhook extends AbstractClient
         }
     }
 
+    /**
+     * Updates an existing webhook.
+     *
+     * Important: due to a bug in BTCPay Server versions <= 1.6.3.0 you need
+     * to pass the $secret explicitly as it would overwrite your existing secret
+     * otherwise. This param will be ignored by newer BTCPay Server versions.
+     * @see https://github.com/btcpayserver/btcpayserver/issues/4010
+     *
+     * @return \BTCPayServer\Result\Webhook
+     * @throws \JsonException
+     */
     public function updateWebhook(
         string $storeId,
         string $url,
         string $webhookId,
         ?array $specificEvents,
+        ?string $secret,
         bool $enabled = true,
         bool $automaticRedelivery = true
     ): \BTCPayServer\Result\Webhook {
         $data = [
           'enabled' => $enabled,
           'automaticRedelivery' => $automaticRedelivery,
-          'url' => $url
+          'url' => $url,
+          'secret' => $secret
         ];
 
         // Specific events or all.

--- a/src/Client/Webhook.php
+++ b/src/Client/Webhook.php
@@ -169,7 +169,9 @@ class Webhook extends AbstractClient
      *
      * Important: due to a bug in BTCPay Server versions <= 1.6.3.0 you need
      * to pass the $secret explicitly as it would overwrite your existing secret
-     * otherwise. This param will be ignored by newer BTCPay Server versions.
+     * otherwise. This will not be needed with BTCPay Server 1.6.4.0 and newer.
+     * If you do NOT set a secret it wont change it and everything will continue
+     * to work.
      * @see https://github.com/btcpayserver/btcpayserver/issues/4010
      *
      * @return \BTCPayServer\Result\Webhook
@@ -180,9 +182,9 @@ class Webhook extends AbstractClient
         string $url,
         string $webhookId,
         ?array $specificEvents,
-        ?string $secret,
         bool $enabled = true,
-        bool $automaticRedelivery = true
+        bool $automaticRedelivery = true,
+        ?string $secret = null
     ): \BTCPayServer\Result\Webhook {
         $data = [
           'enabled' => $enabled,

--- a/src/Client/Webhook.php
+++ b/src/Client/Webhook.php
@@ -169,9 +169,9 @@ class Webhook extends AbstractClient
      *
      * Important: due to a bug in BTCPay Server versions <= 1.6.3.0 you need
      * to pass the $secret explicitly as it would overwrite your existing secret
-     * otherwise. This will not be needed with BTCPay Server 1.6.4.0 and newer.
-     * If you do NOT set a secret it wont change it and everything will continue
-     * to work.
+     * otherwise. On newer versions BTCPay Server >= 1.6.4.0, if you do NOT set
+     * a secret it won't change it and everything will continue to work.
+     *
      * @see https://github.com/btcpayserver/btcpayserver/issues/4010
      *
      * @return \BTCPayServer\Result\Webhook


### PR DESCRIPTION
Adding `secret` param to workaround a bug where BTCPay Server resets the existing secret on calling the webhook update endpoint. See https://github.com/btcpayserver/btcpayserver/issues/4010