### PR TITLE
Replace return type int with float

### DIFF
--- a/src/Result/StoreOnChainWalletFeeRate.php
+++ b/src/Result/StoreOnChainWalletFeeRate.php
@@ -6,7 +6,7 @@ namespace BTCPayServer\Result;
 
 class StoreOnChainWalletFeeRate extends AbstractResult
 {
-    public function getFeeRate(): int
+    public function getFeeRate(): float
     {
         $data = $this->getData();
         return $data['feeRate'];


### PR DESCRIPTION
This method returns fee rate as float, not int. At least with development on testnet I received response of this method as:
array(1) {
  ["feeRate"]=>
  float(1)
}