### PR TITLE
Updated Signature Key, Exception Condition

### DIFF
--- a/examples/webhook.php
+++ b/examples/webhook.php
@@ -58,11 +58,11 @@ class WebhookExample
 
         // verify hmac256
         $headers = getallheaders();
-        $sig = $headers['Btcpay-Sig'];
+        $sig = $headers['BTCPay-Sig'];
 
         $webhookClient = new Webhook($this->host, $this->apiKey);
 
-        if ($webhookClient->isIncomingWebhookRequestValid($raw_post_data, $sig, $this->secret)) {
+        if (!$webhookClient->isIncomingWebhookRequestValid($raw_post_data, $sig, $this->secret)) {
             fwrite(
                 $myfile,
                 $date . " : Error. Invalid Signature detected! \n was: " . $sig . " should be: " . hash_hmac(

--- a/src/Result/Invoice.php
+++ b/src/Result/Invoice.php
@@ -26,7 +26,7 @@ class Invoice extends AbstractResult
 
     public function getId(): string
     {
-        return $this->getData()['amount'];
+        return $this->getData()['id'];
     }
 
     public function getAmount(): float

--- a/src/Result/Invoice.php
+++ b/src/Result/Invoice.php
@@ -24,6 +24,51 @@ class Invoice extends AbstractResult
 
     public const ADDITIONAL_STATUS_PAID_LATE = 'PaidLate';
 
+    public function getId(): string
+    {
+        return $this->getData()['amount'];
+    }
+
+    public function getAmount(): float
+    {
+        return $this->getData()['amount'];
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->getData()['currency'];
+    }
+
+    public function getType(): string
+    {
+        return $this->getData()['type'];
+    }
+
+    public function getCheckoutLink(): string
+    {
+        return $this->getData()['checkoutLink'];
+    }
+
+    public function getCreatedTime(): int
+    {
+        return $this->getData()['createdTime'];
+    }
+
+    public function getExpirationTime(): int
+    {
+        return $this->getData()['expirationTime'];
+    }
+
+    public function getMonitoringTime(): int
+    {
+        return $this->getData()['monitoringTime'];
+    }
+
+    public function isArchived(): bool
+    {
+        return $this->getData()['archived'];
+    }
+
     public function isPaid(): bool
     {
         $data = $this->getData();

--- a/src/Result/Invoice.php
+++ b/src/Result/Invoice.php
@@ -33,7 +33,7 @@ class Invoice extends AbstractResult
 
     public function getAmount(): PreciseNumber
     {
-        return new PreciseNumber($this->getData()['amount']);
+        return PreciseNumber::parseString($this->getData()['amount']);
     }
 
     public function getCurrency(): string

--- a/src/Result/Invoice.php
+++ b/src/Result/Invoice.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Result;
 
+use BTCPayServer\Util\PreciseNumber;
+
 class Invoice extends AbstractResult
 {
     public const STATUS_NEW = 'New';
@@ -29,9 +31,9 @@ class Invoice extends AbstractResult
         return $this->getData()['id'];
     }
 
-    public function getAmount(): float
+    public function getAmount(): PreciseNumber
     {
-        return $this->getData()['amount'];
+        return new PreciseNumber($this->getData()['amount']);
     }
 
     public function getCurrency(): string


### PR DESCRIPTION
Previous example threw error for missing array key, and only worked when the signature was wrong.