### PR TITLE
Miscellaneous Client Test Suite

### DIFF
--- a/src/Client/Miscellaneous.php
+++ b/src/Client/Miscellaneous.php
@@ -6,11 +6,11 @@ namespace BTCPayServer\Client;
 
 use BTCPayServer\Result\InvoiceCheckoutHTML;
 use BTCPayServer\Result\LanguageCodeList;
-use BTCPayServer\Result\PermissionMetadata;
+use BTCPayServer\Result\PermissionMetadataList;
 
 class Miscellaneous extends AbstractClient
 {
-    public function getPermissionMetadata(): PermissionMetadata
+    public function getPermissionMetadata(): PermissionMetadataList
     {
         $url = $this->getBaseUrl() . '/misc/permissions';
         $headers = $this->getRequestHeaders();
@@ -19,7 +19,7 @@ class Miscellaneous extends AbstractClient
         $response = $this->getHttpClient()->request($method, $url, $headers);
 
         if ($response->getStatus() === 200) {
-            return new PermissionMetadata(
+            return new PermissionMetadataList(
                 json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR)
             );
         } else {
@@ -47,7 +47,7 @@ class Miscellaneous extends AbstractClient
     public function getInvoiceCheckout(
         string $invoiceId,
         ?string $lang
-    ): InvoiceCheckoutHTML {
+    ): string {
         $url = $this->getBaseUrl() . '/i/' . urlencode($invoiceId);
 
         //set language query parameter if passed
@@ -61,9 +61,7 @@ class Miscellaneous extends AbstractClient
         $response = $this->getHttpClient()->request($method, $url, $headers);
 
         if ($response->getStatus() === 200) {
-            return new InvoiceCheckoutHTML(
-                json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR)
-            );
+            return $response->getBody();
         } else {
             throw $this->getExceptionByStatusCode($method, $url, $response);
         }

--- a/src/Result/InvoiceCheckoutHTML.php
+++ b/src/Result/InvoiceCheckoutHTML.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace BTCPayServer\Result;
-
-class InvoiceCheckoutHTML extends AbstractResult
-{
-}

--- a/src/Result/LanguageCodeList.php
+++ b/src/Result/LanguageCodeList.php
@@ -7,13 +7,13 @@ namespace BTCPayServer\Result;
 class LanguageCodeList extends AbstractListResult
 {
     /**
-     * @return \BTCPayServer\Result\LanguageCode[]
+     * @return LanguageCode[]
      */
     public function all(): array
     {
         $languageCodes = [];
         foreach ($this->getData() as $languageCode) {
-            $languageCodes[] = new \BTCPayServer\Result\LanguageCode($languageCode);
+            $languageCodes[] = new LanguageCode($languageCode);
         }
         return $languageCodes;
     }

--- a/src/Result/PermissionMetadataList.php
+++ b/src/Result/PermissionMetadataList.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Result;
+
+class PermissionMetadataList extends AbstractListResult
+{
+    /**
+     * @return PermissionMetaData[]
+     */
+    public function all(): array
+    {
+        $permissionMetadataList = [];
+        foreach ($this->getData() as $permissionMetadata) {
+            $permissionMetadataList[] = new PermissionMetadata($permissionMetadata);
+        }
+        return $permissionMetadataList;
+    }
+}

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -44,4 +44,10 @@ class BaseTest extends TestCase
         $this->assertNotEmpty($this->storeId);
         $this->assertNotEmpty($this->nodeUri);
     }
+
+    public function dd($var): void
+    {
+        var_dump($var);
+        die();
+    }
 }

--- a/tests/MiscellaneousTest.php
+++ b/tests/MiscellaneousTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Tests;
+
+use BTCPayServer\Client\Invoice;
+use BTCPayServer\Client\Miscellaneous;
+use BTCPayServer\Result\LanguageCode;
+use BTCPayServer\Result\LanguageCodeList;
+use BTCPayServer\Result\PermissionMetadata;
+use BTCPayServer\Result\PermissionMetadataList;
+use BTCPayServer\Util\PreciseNumber;
+
+final class MiscellaneousTest extends BaseTest
+{
+    private Miscellaneous $miscellaneousClient;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->miscellaneousClient = new Miscellaneous($this->host, $this->apiKey);
+    }
+
+    public function testItCanGetPermissionMetadata(): void
+    {
+        $result = $this->miscellaneousClient->getPermissionMetadata();
+
+        $this->assertInstanceOf(PermissionMetadataList::class, $result);
+
+        foreach($result->all() as $permissionMetadata) {
+            $this->assertInstanceOf(PermissionMetadata::class, $permissionMetadata);
+            $this->assertIsString($permissionMetadata->getName());
+            $this->assertIsArray($permissionMetadata->getIncluded());
+        }
+
+    }
+
+    public function testItCanGetLanguageCodes(): void
+    {
+        $result = $this->miscellaneousClient->getLanguageCodes();
+
+        $this->assertInstanceOf(LanguageCodeList::class, $result);
+
+        foreach($result->all() as $languageCode) {
+            $this->assertInstanceOf(LanguageCode::class, $languageCode);
+            $this->assertIsString($languageCode->getCode());
+            $this->assertIsString($languageCode->getCurrentLanguage());
+        }
+    }
+
+    public function testItCanGetInvoiceCheckout(): void
+    {
+        $invoiceClient = new Invoice($this->host, $this->apiKey);
+
+        $invoice = $invoiceClient->createInvoice(
+            storeId: $this->storeId,
+            currency: 'SATS',
+            amount: PreciseNumber::parseString('1000'),
+        );
+
+        $result = $this->miscellaneousClient->getInvoiceCheckout($invoice->getId(), null);
+
+        $this->assertStringContainsString('<!DOCTYPE html>', $result);
+    }
+}


### PR DESCRIPTION
 - Removes the `InvoiceCheckoutHTML` Result, since response is not an array
 - Changes `getPermissionMetadata` response to `PermissionMetadataList`

![image](https://user-images.githubusercontent.com/70829157/200130799-f0c5592e-5531-4234-bbe4-5269e9203981.png)
![image](https://user-images.githubusercontent.com/70829157/200130835-b162d095-fef1-4fc0-97d5-60bfecbddb3f.png)
![image](https://user-images.githubusercontent.com/70829157/200130855-8a81e04c-1ec4-4e24-bf5f-530556e50592.png)
