### PR TITLE
Miscellaneous Client Test Suite

### DIFF
--- a/src/Client/Miscellaneous.php
+++ b/src/Client/Miscellaneous.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Client;
 
-use BTCPayServer\Result\InvoiceCheckoutHTML;
 use BTCPayServer\Result\LanguageCodeList;
 use BTCPayServer\Result\PermissionMetadataList;
 

--- a/src/Client/Miscellaneous.php
+++ b/src/Client/Miscellaneous.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Client;
 
+use BTCPayServer\Result\InvoiceCheckoutHtml;
 use BTCPayServer\Result\LanguageCodeList;
 use BTCPayServer\Result\PermissionMetadataList;
 
@@ -46,7 +47,7 @@ class Miscellaneous extends AbstractClient
     public function getInvoiceCheckout(
         string $invoiceId,
         ?string $lang
-    ): string {
+    ): InvoiceCheckoutHtml {
         $url = $this->getBaseUrl() . '/i/' . urlencode($invoiceId);
 
         //set language query parameter if passed
@@ -60,7 +61,7 @@ class Miscellaneous extends AbstractClient
         $response = $this->getHttpClient()->request($method, $url, $headers);
 
         if ($response->getStatus() === 200) {
-            return $response->getBody();
+            return new InvoiceCheckoutHtml($response->getBody());
         } else {
             throw $this->getExceptionByStatusCode($method, $url, $response);
         }

--- a/src/Client/Miscellaneous.php
+++ b/src/Client/Miscellaneous.php
@@ -6,11 +6,11 @@ namespace BTCPayServer\Client;
 
 use BTCPayServer\Result\InvoiceCheckoutHTML;
 use BTCPayServer\Result\LanguageCodeList;
-use BTCPayServer\Result\PermissionMetadata;
+use BTCPayServer\Result\PermissionMetadataList;
 
 class Miscellaneous extends AbstractClient
 {
-    public function getPermissionMetadata(): PermissionMetadata
+    public function getPermissionMetadata(): PermissionMetadataList
     {
         $url = $this->getBaseUrl() . '/misc/permissions';
         $headers = $this->getRequestHeaders();
@@ -19,7 +19,7 @@ class Miscellaneous extends AbstractClient
         $response = $this->getHttpClient()->request($method, $url, $headers);
 
         if ($response->getStatus() === 200) {
-            return new PermissionMetadata(
+            return new PermissionMetadataList(
                 json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR)
             );
         } else {
@@ -47,7 +47,7 @@ class Miscellaneous extends AbstractClient
     public function getInvoiceCheckout(
         string $invoiceId,
         ?string $lang
-    ): InvoiceCheckoutHTML {
+    ): string {
         $url = $this->getBaseUrl() . '/i/' . urlencode($invoiceId);
 
         //set language query parameter if passed
@@ -61,9 +61,7 @@ class Miscellaneous extends AbstractClient
         $response = $this->getHttpClient()->request($method, $url, $headers);
 
         if ($response->getStatus() === 200) {
-            return new InvoiceCheckoutHTML(
-                json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR)
-            );
+            return $response->getBody();
         } else {
             throw $this->getExceptionByStatusCode($method, $url, $response);
         }

--- a/src/Result/InvoiceCheckoutHTML.php
+++ b/src/Result/InvoiceCheckoutHTML.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace BTCPayServer\Result;
-
-class InvoiceCheckoutHTML extends AbstractResult
-{
-}

--- a/src/Result/InvoiceCheckoutHtml.php
+++ b/src/Result/InvoiceCheckoutHtml.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Result;
+
+class InvoiceCheckoutHtml
+{
+    /**
+     * @var string
+     */
+    private $html;
+
+    public function __construct(string $html)
+    {
+        $this->html = $html;
+    }
+
+    public function getHtml(): string
+    {
+        return $this->html;
+    }
+
+    public function __toString()
+    {
+        return $this->html;
+    }
+}

--- a/src/Result/LanguageCodeList.php
+++ b/src/Result/LanguageCodeList.php
@@ -7,13 +7,13 @@ namespace BTCPayServer\Result;
 class LanguageCodeList extends AbstractListResult
 {
     /**
-     * @return \BTCPayServer\Result\LanguageCode[]
+     * @return LanguageCode[]
      */
     public function all(): array
     {
         $languageCodes = [];
         foreach ($this->getData() as $languageCode) {
-            $languageCodes[] = new \BTCPayServer\Result\LanguageCode($languageCode);
+            $languageCodes[] = new LanguageCode($languageCode);
         }
         return $languageCodes;
     }

--- a/src/Result/PermissionMetadataList.php
+++ b/src/Result/PermissionMetadataList.php
@@ -7,7 +7,7 @@ namespace BTCPayServer\Result;
 class PermissionMetadataList extends AbstractListResult
 {
     /**
-     * @return PermissionMetaData[]
+     * @return PermissionMetadata[]
      */
     public function all(): array
     {

--- a/src/Result/PermissionMetadataList.php
+++ b/src/Result/PermissionMetadataList.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Result;
+
+class PermissionMetadataList extends AbstractListResult
+{
+    /**
+     * @return PermissionMetaData[]
+     */
+    public function all(): array
+    {
+        $permissionMetadataList = [];
+        foreach ($this->getData() as $permissionMetadata) {
+            $permissionMetadataList[] = new PermissionMetadata($permissionMetadata);
+        }
+        return $permissionMetadataList;
+    }
+}

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -44,4 +44,10 @@ class BaseTest extends TestCase
         $this->assertNotEmpty($this->storeId);
         $this->assertNotEmpty($this->nodeUri);
     }
+
+    public function dd($var): void
+    {
+        var_dump($var);
+        die();
+    }
 }

--- a/tests/MiscellaneousTest.php
+++ b/tests/MiscellaneousTest.php
@@ -29,12 +29,11 @@ final class MiscellaneousTest extends BaseTest
 
         $this->assertInstanceOf(PermissionMetadataList::class, $result);
 
-        foreach($result->all() as $permissionMetadata) {
+        foreach ($result->all() as $permissionMetadata) {
             $this->assertInstanceOf(PermissionMetadata::class, $permissionMetadata);
             $this->assertIsString($permissionMetadata->getName());
             $this->assertIsArray($permissionMetadata->getIncluded());
         }
-
     }
 
     public function testItCanGetLanguageCodes(): void
@@ -43,7 +42,7 @@ final class MiscellaneousTest extends BaseTest
 
         $this->assertInstanceOf(LanguageCodeList::class, $result);
 
-        foreach($result->all() as $languageCode) {
+        foreach ($result->all() as $languageCode) {
             $this->assertInstanceOf(LanguageCode::class, $languageCode);
             $this->assertIsString($languageCode->getCode());
             $this->assertIsString($languageCode->getCurrentLanguage());

--- a/tests/MiscellaneousTest.php
+++ b/tests/MiscellaneousTest.php
@@ -6,6 +6,7 @@ namespace BTCPayServer\Tests;
 
 use BTCPayServer\Client\Invoice;
 use BTCPayServer\Client\Miscellaneous;
+use BTCPayServer\Result\InvoiceCheckoutHtml;
 use BTCPayServer\Result\LanguageCode;
 use BTCPayServer\Result\LanguageCodeList;
 use BTCPayServer\Result\PermissionMetadata;
@@ -61,6 +62,7 @@ final class MiscellaneousTest extends BaseTest
 
         $result = $this->miscellaneousClient->getInvoiceCheckout($invoice->getId(), null);
 
-        $this->assertStringContainsString('<!DOCTYPE html>', $result);
+        $this->assertInstanceOf(InvoiceCheckoutHtml::class, $result);
+        $this->assertStringContainsString('<!DOCTYPE html>', $result->getHtml());
     }
 }

--- a/tests/MiscellaneousTest.php
+++ b/tests/MiscellaneousTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Tests;
+
+use BTCPayServer\Client\Invoice;
+use BTCPayServer\Client\Miscellaneous;
+use BTCPayServer\Result\LanguageCode;
+use BTCPayServer\Result\LanguageCodeList;
+use BTCPayServer\Result\PermissionMetadata;
+use BTCPayServer\Result\PermissionMetadataList;
+use BTCPayServer\Util\PreciseNumber;
+
+final class MiscellaneousTest extends BaseTest
+{
+    private Miscellaneous $miscellaneousClient;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->miscellaneousClient = new Miscellaneous($this->host, $this->apiKey);
+    }
+
+    public function testItCanGetPermissionMetadata(): void
+    {
+        $result = $this->miscellaneousClient->getPermissionMetadata();
+
+        $this->assertInstanceOf(PermissionMetadataList::class, $result);
+
+        foreach($result->all() as $permissionMetadata) {
+            $this->assertInstanceOf(PermissionMetadata::class, $permissionMetadata);
+            $this->assertIsString($permissionMetadata->getName());
+            $this->assertIsArray($permissionMetadata->getIncluded());
+        }
+
+    }
+
+    public function testItCanGetLanguageCodes(): void
+    {
+        $result = $this->miscellaneousClient->getLanguageCodes();
+
+        $this->assertInstanceOf(LanguageCodeList::class, $result);
+
+        foreach($result->all() as $languageCode) {
+            $this->assertInstanceOf(LanguageCode::class, $languageCode);
+            $this->assertIsString($languageCode->getCode());
+            $this->assertIsString($languageCode->getCurrentLanguage());
+        }
+    }
+
+    public function testItCanGetInvoiceCheckout(): void
+    {
+        $invoiceClient = new Invoice($this->host, $this->apiKey);
+
+        $invoice = $invoiceClient->createInvoice(
+            storeId: $this->storeId,
+            currency: 'SATS',
+            amount: PreciseNumber::parseString('1000'),
+        );
+
+        $result = $this->miscellaneousClient->getInvoiceCheckout($invoice->getId(), null);
+
+        $this->assertStringContainsString('<!DOCTYPE html>', $result);
+    }
+}


### PR DESCRIPTION
- Changes the `InvoiceCheckoutHTML` Result to `InvoiceCheckoutHtml`, adds method `getHtml()` and uses `__toString` to allow the object to also return a string of HTML.
- Changes `getPermissionMetadata` response to `PermissionMetadataList`
![image](https://user-images.githubusercontent.com/111649294/200131004-5267ed54-2458-4521-b493-aaa3eba99e2d.png)