### PR TITLE
Make tests work with environment secrets.

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,20 +1,20 @@
 name: PHP Unit Tests
-env:
-  BTCPAY_HOST: ${{ secrets.BTCPAY_HOST }}
-  BTCPAY_API_KEY: ${{ secrets.BTCPAY_API_KEY }}
-  BTCPAY_STORE_ID: ${{ secrets.BTCPAY_STORE_ID }}
-  BTCPAY_NODE_URI: ${{ secrets.BTCPAY_NODE_URI }}
 on: [ push, pull_request ]
 
 jobs:
   phpunit:
     runs-on: ubuntu-latest
+    environment: phpunittest
+    env:
+      BTCPAY_HOST: ${{ secrets.BTCPAY_HOST }}
+      BTCPAY_API_KEY: ${{ secrets.BTCPAY_API_KEY }}
+      BTCPAY_STORE_ID: ${{ secrets.BTCPAY_STORE_ID }}
+      BTCPAY_NODE_URI: ${{ secrets.BTCPAY_NODE_URI }}
     strategy:
       matrix:
         php-versions: ['8.0', '8.1']
         phpunit-versions: ['latest']
 
-        
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -19,17 +19,22 @@ class BaseTest extends TestCase
         $dotenv = Dotenv::createImmutable(__DIR__);
         $dotenv->safeLoad();
 
-        if (!isset($_ENV['BTCPAY_API_KEY'], $_ENV['BTCPAY_HOST'], $_ENV['BTCPAY_STORE_ID'], $_ENV['BTCPAY_NODE_URI'])) {
+        $apiKey = getenv('BTCPAY_API_KEY');
+        $host = getenv('BTCPAY_HOST');
+        $storeId = getenv('BTCPAY_STORE_ID');
+        $nodeUri = getenv('BTCPAY_NODE_URI');
+
+        if (!$apiKey || !$host || !$storeId || !$nodeUri) {
             throw new \Exception('Missing .env variables');
         }
     }
 
     protected function setUp(): void
     {
-        $this->host = $_ENV['BTCPAY_HOST'];
-        $this->apiKey = $_ENV['BTCPAY_API_KEY'];
-        $this->nodeUri = $_ENV['BTCPAY_NODE_URI'];
-        $this->storeId = $_ENV['BTCPAY_STORE_ID'];
+        $this->host = getenv('BTCPAY_HOST');
+        $this->apiKey = getenv('BTCPAY_API_KEY');
+        $this->nodeUri = getenv('BTCPAY_NODE_URI');
+        $this->storeId = getenv('BTCPAY_STORE_ID');
     }
 
     public function testItSetsAllTheEnvironmentVariables(): void


### PR DESCRIPTION
While repository secrets work on my own fork of this repo it seems that they don't for non-admin users on pull requests as they could leak confidential data on running the workflows. Also in every case $_ENV is empty because of PHP config, `getenv()` works though. 