### PR TITLE
Update AbstractListResult.php

### DIFF
--- a/src/Result/AbstractListResult.php
+++ b/src/Result/AbstractListResult.php
@@ -6,7 +6,7 @@ namespace BTCPayServer\Result;
 
 abstract class AbstractListResult extends AbstractResult implements \Countable
 {
-    public function count()
+    public function count(): int
     {
         return count($this->getData());
     }


### PR DESCRIPTION
Fix: Fatal error: During inheritance of Countable: Uncaught Exception: Deprecated Functionality: Return type of BTCPayServer\Result\AbstractListResult::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /******/btcpayserver-greenfield-php/src/Result/AbstractListResult.php on line 9