### PR TITLE
StoreClient Tests + Result Updates

### DIFF
--- a/src/Client/Store.php
+++ b/src/Client/Store.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BTCPayServer\Client;
 
 use BTCPayServer\Result\Store as ResultStore;
+use BTCPayServer\Result\StoreList;
 
 class Store extends AbstractClient
 {
@@ -98,9 +99,9 @@ class Store extends AbstractClient
     }
 
     /**
-     * @return \BTCPayServer\Result\Store[]
+     * @return \BTCPayServer\Result\StoreList
      */
-    public function getStores(): array
+    public function getStores(): StoreList
     {
         $url = $this->getApiUrl() . 'stores';
         $headers = $this->getRequestHeaders();
@@ -110,11 +111,7 @@ class Store extends AbstractClient
         if ($response->getStatus() === 200) {
             $r = [];
             $data = json_decode($response->getBody(), true);
-            foreach ($data as $item) {
-                $item = new ResultStore($item);
-                $r[] = $item;
-            }
-            return $r;
+            return new StoreList($data);
         } else {
             throw $this->getExceptionByStatusCode($method, $url, $response);
         }

--- a/src/Client/Store.php
+++ b/src/Client/Store.php
@@ -109,7 +109,6 @@ class Store extends AbstractClient
         $response = $this->getHttpClient()->request($method, $url, $headers);
 
         if ($response->getStatus() === 200) {
-            $r = [];
             $data = json_decode($response->getBody(), true);
             return new StoreList($data);
         } else {

--- a/src/Result/Store.php
+++ b/src/Result/Store.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace BTCPayServer\Result;
 
+use BTCPayServer\Util\PreciseNumber;
+
 class Store extends AbstractResult
 {
     public function getName(): string
@@ -12,13 +14,14 @@ class Store extends AbstractResult
         return $data['name'];
     }
 
-    public function getWebsite(): string
+    public function getWebsite():? string
     {
         $data = $this->getData();
         return $data['website'];
     }
 
-    public function getDefaultCurrency(): string
+    // Temporarily allowing null as it appears Greenfield has a bug.
+    public function getDefaultCurrency():? string
     {
         $data = $this->getData();
         return $data['defaultCurrency'];
@@ -48,10 +51,10 @@ class Store extends AbstractResult
         return $data['lightningDescriptionTemplate'];
     }
 
-    public function getPaymentTolerance(): int
+    public function getPaymentTolerance(): PreciseNumber
     {
         $data = $this->getData();
-        return $data['paymentTolerance'];
+        return PreciseNumber::parseFloat($data['paymentTolerance']);
     }
 
     public function anyoneCanCreateInvoice(): bool
@@ -102,25 +105,25 @@ class Store extends AbstractResult
         return $data['recommendedFeeBlockTarget'];
     }
 
-    public function getDefaultLang(): string
+    public function getDefaultLang():? string
     {
         $data = $this->getData();
         return $data['defaultLang'];
     }
 
-    public function getCustomLogo(): string
+    public function getCustomLogo():? string
     {
         $data = $this->getData();
         return $data['customLogo'];
     }
 
-    public function getCustomCSS(): string
+    public function getCustomCSS():? string
     {
         $data = $this->getData();
         return $data['customCSS'];
     }
 
-    public function getHtmlTitle(): string
+    public function getHtmlTitle():? string
     {
         $data = $this->getData();
         return $data['htmlTitle'];
@@ -144,7 +147,7 @@ class Store extends AbstractResult
         return $data['lazyPaymentMethods'];
     }
 
-    public function getDefaultPaymentMethod(): string
+    public function getDefaultPaymentMethod():? string
     {
         $data = $this->getData();
         return $data['defaultPaymentMethod'];

--- a/src/Result/Store.php
+++ b/src/Result/Store.php
@@ -14,14 +14,13 @@ class Store extends AbstractResult
         return $data['name'];
     }
 
-    public function getWebsite():? string
+    public function getWebsite(): ?string
     {
         $data = $this->getData();
         return $data['website'];
     }
 
-    // Temporarily allowing null as it appears Greenfield has a bug.
-    public function getDefaultCurrency():? string
+    public function getDefaultCurrency(): ?string
     {
         $data = $this->getData();
         return $data['defaultCurrency'];
@@ -105,25 +104,25 @@ class Store extends AbstractResult
         return $data['recommendedFeeBlockTarget'];
     }
 
-    public function getDefaultLang():? string
+    public function getDefaultLang(): ?string
     {
         $data = $this->getData();
         return $data['defaultLang'];
     }
 
-    public function getCustomLogo():? string
+    public function getCustomLogo(): ?string
     {
         $data = $this->getData();
         return $data['customLogo'];
     }
 
-    public function getCustomCSS():? string
+    public function getCustomCSS(): ?string
     {
         $data = $this->getData();
         return $data['customCSS'];
     }
 
-    public function getHtmlTitle():? string
+    public function getHtmlTitle(): ?string
     {
         $data = $this->getData();
         return $data['htmlTitle'];
@@ -147,7 +146,7 @@ class Store extends AbstractResult
         return $data['lazyPaymentMethods'];
     }
 
-    public function getDefaultPaymentMethod():? string
+    public function getDefaultPaymentMethod(): ?string
     {
         $data = $this->getData();
         return $data['defaultPaymentMethod'];

--- a/src/Result/StoreList.php
+++ b/src/Result/StoreList.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Result;
+
+class StoreList extends AbstractListResult
+{
+    /**
+     * @return Store[]
+     */
+    public function all(): array
+    {
+        $stores = [];
+        foreach ($this->getData() as $store) {
+            $stores[] = new Store($store);
+        }
+        return $stores;
+    }
+}

--- a/tests/StoreTest.php
+++ b/tests/StoreTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BTCPayServer\Tests;
+
+use BTCPayServer\Client\Store;
+use BTCPayServer\Result\Store as ResultStore;
+use BTCPayServer\Result\StoreList;
+use BTCPayServer\Util\PreciseNumber;
+
+final class StoreTest extends BaseTest
+{
+    public Store $storeClient;
+    public ResultStore $store;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->storeClient = new Store($this->host, $this->apiKey);
+        $this->store = $this->storeClient->createStore(
+            name: 'Test Store',
+            website: 'https://example.com',
+            defaultCurrency: 'USD',
+            invoiceExpiration: 900,
+            displayExpirationTimer: 300,
+            monitoringExpiration: 3600,
+            speedPolicy: 'MediumSpeed',
+            lightningDescriptionTemplate: null,
+            paymentTolerance: 0,
+            anyoneCanCreateInvoice: false,
+            requiresRefundEmail: false,
+            checkoutType: 'V1',
+            receipt: null,
+            lightningAmountInSatoshi: false,
+            lightningPrivateRouteHints: false,
+            onChainWithLnInvoiceFallback: false,
+            redirectAutomatically: false,
+            showRecommendedFee: true,
+            recommendedFeeBlockTarget: 1,
+            defaultLang: 'en',
+            customLogo: 'https://test.com',
+            customCSS: 'auto: 100px;',
+            htmlTitle: 'the best store ever',
+            networkFeeMode: 'MultiplePaymentsOnly',
+            payJoinEnabled: false,
+            lazyPaymentMethods: false,
+            defaultPaymentMethod: 'BTC'
+        );
+    }
+
+    /** @group createStore */
+    public function testItCanCreateAStore(): void
+    {
+        $this->assertStoreGettersAreSet($this->store);
+    }
+
+    /** @group getStores */
+    public function testItCanGetAllStores(): void
+    {
+        $stores = $this->storeClient->getStores();
+
+        $this->assertInstanceOf(StoreList::class, $stores);
+
+        foreach ($stores->all() as $store) {
+            $this->assertStoreGettersAreSet($store);
+        }
+    }
+
+    /** @group getStore */
+    public function testItCanGetAnIndividualStore(): void
+    {
+        $store = $this->storeClient->getStore($this->store->getId());
+        $this->assertStoreGettersAreSet($store);
+    }
+
+    private function assertStoreGettersAreSet(ResultStore $store): void
+    {
+        $this->assertInstanceOf(ResultStore::class, $store);
+        $this->assertIsString($store->getName());
+        $this->assertIsInt($store->getInvoiceExpiration());
+        $this->assertIsInt($store->getMonitoringExpiration());
+        $this->assertIsString($store->getSpeedPolicy());
+        $this->assertIsString($store->getLightningDescriptionTemplate());
+        $this->assertInstanceOf(PreciseNumber::class, $store->getPaymentTolerance());
+        $this->assertIsBool($store->anyoneCanCreateInvoice());
+        $this->assertIsBool($store->requiresRefundEmail());
+        $this->assertIsBool($store->lightningAmountInSatoshi());
+        $this->assertIsBool($store->lightningPrivateRouteHints());
+        $this->assertIsBool($store->onChainWithLnInvoiceFallback());
+        $this->assertIsBool($store->redirectAutomatically());
+        $this->assertIsBool($store->showRecommendedFee());
+        $this->assertIsInt($store->getRecommendedFeeBlockTarget());
+        //$this->assertIsString($store->getDefaultLang());
+        if ($store->getCustomLogo() !== null) {
+            $this->assertIsString($store->getCustomLogo());
+        }
+        
+        if ($store->getCustomCSS() !== null) {
+            $this->assertIsString($store->getCustomCSS());
+        }
+        
+        if ($store->getHtmlTitle() !== null) {
+            $this->assertIsString($store->getHtmlTitle());
+        }
+        if ($store->getWebsite() !== null) {
+            $this->assertIsString($store->getWebsite());
+        }
+        if ($store->getDefaultPaymentMethod() !== null) {
+            $this->assertIsString($store->getDefaultPaymentMethod());
+        }
+        
+        $this->assertIsString($store->getNetworkFeeMode());
+        $this->assertIsBool($store->payJoinEnabled());
+        $this->assertIsBool($store->lazyPaymentMethods());
+        //$this->assertIsString($store->getDefaultPaymentMethod());
+        $this->assertIsString($store->getId());
+    }
+}

--- a/tests/StoreTest.php
+++ b/tests/StoreTest.php
@@ -92,7 +92,7 @@ final class StoreTest extends BaseTest
         $this->assertIsBool($store->redirectAutomatically());
         $this->assertIsBool($store->showRecommendedFee());
         $this->assertIsInt($store->getRecommendedFeeBlockTarget());
-        //$this->assertIsString($store->getDefaultLang());
+
         if ($store->getCustomLogo() !== null) {
             $this->assertIsString($store->getCustomLogo());
         }
@@ -114,7 +114,6 @@ final class StoreTest extends BaseTest
         $this->assertIsString($store->getNetworkFeeMode());
         $this->assertIsBool($store->payJoinEnabled());
         $this->assertIsBool($store->lazyPaymentMethods());
-        //$this->assertIsString($store->getDefaultPaymentMethod());
         $this->assertIsString($store->getId());
     }
 }

--- a/tests/StoreTest.php
+++ b/tests/StoreTest.php
@@ -96,11 +96,11 @@ final class StoreTest extends BaseTest
         if ($store->getCustomLogo() !== null) {
             $this->assertIsString($store->getCustomLogo());
         }
-        
+
         if ($store->getCustomCSS() !== null) {
             $this->assertIsString($store->getCustomCSS());
         }
-        
+
         if ($store->getHtmlTitle() !== null) {
             $this->assertIsString($store->getHtmlTitle());
         }
@@ -110,7 +110,7 @@ final class StoreTest extends BaseTest
         if ($store->getDefaultPaymentMethod() !== null) {
             $this->assertIsString($store->getDefaultPaymentMethod());
         }
-        
+
         $this->assertIsString($store->getNetworkFeeMode());
         $this->assertIsBool($store->payJoinEnabled());
         $this->assertIsBool($store->lazyPaymentMethods());


### PR DESCRIPTION
 - Allows multiple getters to accept null values in-line with the api
 - Creates the `StoreList` object type to replace array
 - Fully tests all methods in the StoreClient class

![image](https://github.com/btcpayserver/btcpayserver-greenfield-php/assets/111649294/aeb15b15-9778-44d3-aa1e-b6231f109134)

![image](https://github.com/btcpayserver/btcpayserver-greenfield-php/assets/111649294/9534879c-9de6-47d6-ba12-c04f11c1e700)
