### PR TITLE
Adding payout parameter for BTCPay >=2.0 compatibilty.

### DIFF
--- a/examples/payout_usage.php
+++ b/examples/payout_usage.php
@@ -43,7 +43,7 @@ class PullPayments
         $autoApproveClaims = false;
         $startsAt = null;
         $expiresAt = null;
-        $paymentMethods = ['BTC'];
+        $paymentMethods = ['BTC-CHAIN'];
 
         try {
             $client = new PullPayment($this->host, $this->apiKey);
@@ -163,7 +163,7 @@ class PullPayments
         $pullPaymentId = '';
         $destination = '';
         $amount = PreciseNumber::parseString('0.000001');
-        $paymentMethod = '';
+        $paymentMethod = 'BTC-CHAIN';
 
         try {
             $client = new PullPayment($this->host, $this->apiKey);

--- a/src/Client/PullPayment.php
+++ b/src/Client/PullPayment.php
@@ -244,6 +244,7 @@ class PullPayment extends AbstractClient
                 'destination' => $destination,
                 'amount' => $amount->__toString(),
                 'paymentMethod' => $paymentMethod,
+                'payoutMethodId' => $paymentMethod, // BTCPay 2.0.0 compatibilty
             ],
             JSON_THROW_ON_ERROR
         );


### PR DESCRIPTION
Fixes #136 and keeps backward compatibilty to BTCPay 1.x